### PR TITLE
Setup Travis and basic file structure

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,7 @@
+# IDE files
+.idea/
+.vscode/
+
+# build directories
+cmake-build-debug/
+build/

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,2 @@
+language: cpp
+script: mkdir build && cd build && cmake .. && make

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,0 +1,12 @@
+cmake_minimum_required(VERSION 3.0)
+project(durian)
+
+set(CMAKE_CXX_STANDARD 14)
+
+include_directories(${PROJECT_SOURCE_DIR}/src/include)
+
+set(SOURCE_FILES
+        src/main.cpp)
+
+add_executable(durian
+        ${SOURCE_FILES})

--- a/README.md
+++ b/README.md
@@ -1,1 +1,22 @@
 # durian
+
+## Building
+
+If you use CLion IDE, the project should "just work" if you import it as a new project (since CMake is integrated into CLion),
+and you should be able to click the build/run button, which will put build artifacts into the `cmake-build-debug/` directory by default.
+
+If you are using a Unix-based system (i.e. Linux or macOS) and you would like to build from the command line,
+you can do so with the following set of commands in the repo's main directory:
+
+```
+mkdir build
+cd build/
+cmake ..
+make
+```
+
+To briefly explain, this:
+
+* Creates a new directory named `build/` and enters it.
+* Calls CMake to create the build system in the current directory (i.e. `build/`), telling it that the CMakeLists.txt config file is in the parent directory (i.e. `..`).
+* Calls make (i.e. the generated build system) in the `build/` directory to compile the code.

--- a/src/include/README.md
+++ b/src/include/README.md
@@ -1,0 +1,5 @@
+Header files should go here.
+
+Note that since this directory is among the `include_directories` in CMakeLists.txt,
+you can use angle brackets to refer to headers here;
+e.g. you can do `#include <Example.h>`.

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -1,0 +1,3 @@
+int main() {
+    return 0;
+}


### PR DESCRIPTION
I created a `main` function as well as a basic directory structure, and also set up Travis so that it can build on every pull request (this will however need to be activated on [travis-ci.org](travis-ci.org)). Also I set the C++ standard to C++14 for the time being; it doesn't change much from C++11 (i.e. modern C++) but since we don't really have to worry about backwards compatibility and cross-platform and so on, we might as well use the most recent version.