### PR TITLE
Fix errors with Token

### DIFF
--- a/src/include/Token.h
+++ b/src/include/Token.h
@@ -20,13 +20,13 @@ enum struct TokenType {
     Def, Let, Equal, Identifier,
 
     // Control-flow keywords
-    Bang, And, Or, If, Else, Elif, While, Return, Next, Break,
+    Bang, If, Else, Elif, While, Return, Next, Break,
 
     // I/O keywords
     Print, Scan, Err,
 
     // File tokens
-    EOL, EOF
+    EOL, END
 };
 
 struct Token {


### PR DESCRIPTION
:tickets: **Ticket(s)**: Affects #13

---

## :construction_worker: Changes

Token.h (because it wasn't `#include`-d anywhere) wasn't actually being compiled and thus errors were not being checked. While setting up the lexer I discovered two problems:

* I had mistakenly repeated the `And` and `Or` keywords.
* `EOF` is apparently defined as a macro in `stdio` and thus expands to the value -1, which makes the compiler unhappy. I've changed the `EOF` token to `END`---not ideal but off the top of my head I can't think of a workaround.

## :flashlight: Testing Instructions

No changes necessary.