### PR TITLE
Implement 1- and 2-character token lexing and string lexing

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -8,6 +8,7 @@ include_directories(${PROJECT_SOURCE_DIR}/src/include)
 add_subdirectory(googletest/)
 
 set(SOURCE_FILES
+        src/lexer/Lexer.cpp
         src/ExampleClass.cpp)
 
 set(TEST_FILES

--- a/src/include/Lexer.h
+++ b/src/include/Lexer.h
@@ -1,0 +1,17 @@
+#pragma once
+
+#include <string>
+
+#include <Token.h>
+
+class Lexer {
+private:
+    const std::string m_input;
+    std::string::const_iterator m_iter;
+    uint32_t m_line;
+public:
+    Lexer(const std::string input);
+    Token getToken();
+};
+
+

--- a/src/include/Token.h
+++ b/src/include/Token.h
@@ -25,8 +25,8 @@ enum struct TokenType {
     // I/O keywords
     Print, Scan, Err,
 
-    // File tokens
-    EOL, END
+    // Control tokens
+    EOL, END, Error
 };
 
 struct Token {

--- a/src/lexer/Lexer.cpp
+++ b/src/lexer/Lexer.cpp
@@ -1,0 +1,99 @@
+#include <Lexer.h>
+
+Lexer::Lexer(const std::string input)
+    : m_input(input)
+    , m_iter(input.cbegin())
+    , m_line(1)
+{
+
+}
+
+Token Lexer::getToken() {
+    std::string literal;
+    if (m_iter == m_input.cend()) return Token {TokenType::END, m_line, ""};
+    while (*m_iter == ' ') {
+        ++m_iter;
+    }
+    switch (*m_iter) {
+        case ',':
+            ++m_iter;
+            return Token {TokenType::Comma, m_line, ""};
+        case '{':
+            ++m_iter;
+            return Token {TokenType::LeftBrace, m_line, ""};
+        case '}':
+            ++m_iter;
+            return Token {TokenType::RightBrace, m_line, ""};
+        case '(':
+            ++m_iter;
+            return Token {TokenType::LeftParen, m_line, ""};
+        case ')':
+            ++m_iter;
+            return Token {TokenType::RightParen, m_line, ""};
+        case '&':
+            ++m_iter;
+            return Token {TokenType::Ampersand, m_line, ""};
+        case '+':
+            ++m_iter;
+            return Token {TokenType::Plus, m_line, ""};
+        case '-':
+            ++m_iter;
+            return Token {TokenType::Minus, m_line, ""};
+        case '*':
+            ++m_iter;
+            return Token {TokenType::Star, m_line, ""};
+        case '/':
+            ++m_iter;
+            return Token {TokenType::Slash, m_line, ""};
+        case '=':
+            ++m_iter;
+            if (*m_iter == '=') {
+                ++m_iter;
+                return Token {TokenType::EqualEqual, m_line, ""};
+            }
+            return Token {TokenType::Equal, m_line, ""};
+        case '!':
+            ++m_iter;
+            if (*m_iter == '=') {
+                ++m_iter;
+                return Token {TokenType::BangEqual, m_line, ""};
+            }
+            return Token {TokenType::Bang, m_line, ""};
+        case '>':
+            ++m_iter;
+            if (*m_iter == '=') {
+                ++m_iter;
+                return Token {TokenType::GreaterEqual, m_line, ""};
+            }
+            return Token {TokenType::Greater, m_line, ""};
+        case '<':
+            ++m_iter;
+            if (*m_iter == '=') {
+                ++m_iter;
+                return Token {TokenType::LesserEqual, m_line, ""};
+            }
+            return Token {TokenType::Lesser, m_line, ""};
+        case '\n':
+            ++m_iter;
+            return Token {TokenType::EOL, m_line++, ""};
+        case '\r':
+            ++m_iter;
+            if (*m_iter == '\n') {
+                ++m_iter;
+                return Token {TokenType::EOL, m_line++, ""};
+            }
+            return Token {TokenType::Error, m_line, "Found carriage return but no newline."};
+        case '"':
+            while (*(++m_iter) != '"') {
+                literal += *m_iter;
+            }
+            ++m_iter;
+            return Token {TokenType::String, m_line, literal};
+        default:
+            // TODO check if token is digit or alphabetic
+            // if digit: parse as int or float
+            // if alphabetic: parse until whitespace (?),
+            // then check against list of keywords
+            return Token {TokenType::Error, m_line, "No matching token for character."};
+    }
+}

--- a/test/main.cpp
+++ b/test/main.cpp
@@ -1,7 +1,60 @@
 #include <gtest/gtest.h>
 
 #include <ExampleClass.h>
+#include <Lexer.h>
 
 TEST(TestExClass, TestRetOne) {
     EXPECT_EQ(ExampleClass::returnOne(), 1);
+}
+
+TEST(TestLexer, TestSingleComma) {
+    Lexer lexer(",");
+    Token tok = lexer.getToken();
+    EXPECT_EQ(tok.type, TokenType::Comma);
+    EXPECT_EQ(tok.line, 1);
+    EXPECT_EQ(tok.literal, "");
+}
+
+TEST(TestLexer, TestParenCommaParen) {
+    Lexer lexer("(,)");
+    Token tok1 = lexer.getToken();
+    Token tok2 = lexer.getToken();
+    Token tok3 = lexer.getToken();
+    EXPECT_EQ(tok1.type, TokenType::LeftParen);
+    EXPECT_EQ(tok1.line, 1);
+    EXPECT_EQ(tok1.literal, "");
+    EXPECT_EQ(tok2.type, TokenType::Comma);
+    EXPECT_EQ(tok2.line, 1);
+    EXPECT_EQ(tok2.literal, "");
+    EXPECT_EQ(tok3.type, TokenType::RightParen);
+    EXPECT_EQ(tok3.line, 1);
+    EXPECT_EQ(tok3.literal, "");
+}
+
+TEST(TestLexer, TestString) {
+    Lexer lexer("\"Hi, this is a string.\"");
+    Token tok = lexer.getToken();
+    EXPECT_EQ(tok.type, TokenType::String);
+    EXPECT_EQ(tok.line, 1);
+    EXPECT_EQ(tok.literal, "Hi, this is a string.");
+}
+
+TEST(TestLexer, TestIgnoreWhitespace) {
+    Lexer lexer("  ( ,) }");
+    Token tok1 = lexer.getToken();
+    Token tok2 = lexer.getToken();
+    Token tok3 = lexer.getToken();
+    Token tok4 = lexer.getToken();
+    EXPECT_EQ(tok1.type, TokenType::LeftParen);
+    EXPECT_EQ(tok1.line, 1);
+    EXPECT_EQ(tok1.literal, "");
+    EXPECT_EQ(tok2.type, TokenType::Comma);
+    EXPECT_EQ(tok2.line, 1);
+    EXPECT_EQ(tok2.literal, "");
+    EXPECT_EQ(tok3.type, TokenType::RightParen);
+    EXPECT_EQ(tok3.line, 1);
+    EXPECT_EQ(tok3.literal, "");
+    EXPECT_EQ(tok4.type, TokenType::RightBrace);
+    EXPECT_EQ(tok4.line, 1);
+    EXPECT_EQ(tok4.literal, "");
 }


### PR DESCRIPTION
:tickets: **Ticket(s)**: Affects #14

---

## :construction_worker: Changes

Created the main lexer class and implemented `getToken()` for 1- and 2-chararacter tokens as well as string literals, and also implemented whitespace stripping. This is still missing identifiers, reserved keywords, and numerical literals, as well as comments (which we haven't decided on at time of PR).

Also added an `Error` token type for lexing errors.

## :flashlight: Testing Instructions

Added unit tests to `test/main.cpp`.