### PR TITLE
Remove build examples

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -8,11 +8,10 @@ include_directories(${PROJECT_SOURCE_DIR}/src/include)
 add_subdirectory(googletest/)
 
 set(SOURCE_FILES
-        src/lexer/Lexer.cpp
-        src/ExampleClass.cpp)
+        src/lexer/Lexer.cpp)
 
 set(TEST_FILES
-        test/main.cpp)
+        test/TestLexer.cpp)
 
 add_executable(durian
         src/main.cpp

--- a/src/ExampleClass.cpp
+++ b/src/ExampleClass.cpp
@@ -1,5 +1,0 @@
-#include <ExampleClass.h>
-
-int ExampleClass::returnOne() {
-    return 1;
-}

--- a/src/include/ExampleClass.h
+++ b/src/include/ExampleClass.h
@@ -1,7 +1,0 @@
-#pragma once
-
-class ExampleClass {
-    public:
-        static int returnOne();
-};
-

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -1,7 +1,5 @@
 #include <iostream>
-#include <ExampleClass.h>
 
 int main() {
-    std::cout << ExampleClass::returnOne();
     return 0;
 }

--- a/test/TestLexer.cpp
+++ b/test/TestLexer.cpp
@@ -1,11 +1,6 @@
 #include <gtest/gtest.h>
 
-#include <ExampleClass.h>
 #include <Lexer.h>
-
-TEST(TestExClass, TestRetOne) {
-    EXPECT_EQ(ExampleClass::returnOne(), 1);
-}
 
 TEST(TestLexer, TestSingleComma) {
     Lexer lexer(",");


### PR DESCRIPTION
:tickets: **Ticket(s)**: 

---

## :construction_worker: Changes

Remove `ExampleClass` and rename the file containing unit tests for `Lexer`.

## :flashlight: Testing Instructions

No testing necessary.