### PR TITLE
Add warnings and other minor options to CMakeLists

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,7 +1,9 @@
 cmake_minimum_required(VERSION 3.0)
-project(durian)
+project(durian LANGUAGES CXX)
 
 set(CMAKE_CXX_STANDARD 11)
+set(CMAKE_CXX_STANDARD_REQUIRED ON)
+set(CMAKE_CXX_EXTENSIONS OFF)
 
 include_directories(src/include)
 
@@ -24,3 +26,23 @@ add_executable(durian_test
         ${TEST_FILES})
 
 target_link_libraries(durian_test gtest_main)
+
+if (CMAKE_CXX_COMPILER_ID MATCHES "Clang|AppleClang|GNU")
+    target_compile_options(VM PRIVATE -Wall -Wextra -Wunreachable-code -Wpedantic)
+endif()
+if (CMAKE_CXX_COMPILER_ID MATCHES "Clang")
+    target_compile_options(VM PRIVATE -Wweak-vtables -Wexit-time-destructors -Wglobal-constructors -Wmissing-noreturn )
+endif()
+if (CMAKE_CXX_COMPILER_ID MATCHES "MSVC")
+    target_compile_options(VM PRIVATE /W4 /w44265 /w44061 /w44062 )
+endif()
+
+if (CMAKE_CXX_COMPILER_ID MATCHES "Clang|AppleClang|GNU")
+    target_compile_options(durian_test PRIVATE -Wall -Wextra -Wunreachable-code -Wpedantic)
+endif()
+if (CMAKE_CXX_COMPILER_ID MATCHES "Clang")
+    target_compile_options(durian_test PRIVATE -Wweak-vtables -Wexit-time-destructors -Wglobal-constructors -Wmissing-noreturn )
+endif()
+if (CMAKE_CXX_COMPILER_ID MATCHES "MSVC")
+    target_compile_options(durian_test PRIVATE /W4 /w44265 /w44061 /w44062 )
+endif()


### PR DESCRIPTION
---

## :construction_worker: Changes

This enables more compiler warnings as well as some other minor changes.

For details see: https://codingnest.com/basic-cmake/

## :flashlight: Testing Instructions

It still builds on master, and since it doesn't touch any of the targets (it just enables extra options), it shouldn't conflict with any further development.