### PR TITLE
Add checkToken test helper and TestEatDurianEx

### DIFF
--- a/src/include/Token.h
+++ b/src/include/Token.h
@@ -26,6 +26,9 @@ enum struct TokenType {
     Print, Scan, Err,
 
     // Control tokens
+    // Note: END represents EOF;
+    // however EOF is defined as a macro in the standard library
+    // and so is unusable here
     EOL, END, Error
 };
 

--- a/test/TestLexer.cpp
+++ b/test/TestLexer.cpp
@@ -2,118 +2,87 @@
 
 #include <Lexer.h>
 
+void checkToken(Token tok, TokenType expectedType, uint32_t expectedLine, std::string expectedLit) {
+    EXPECT_EQ(tok.type, expectedType);
+    EXPECT_EQ(tok.line, expectedLine);
+    EXPECT_EQ(tok.literal, expectedLit);
+}
+
 TEST(TestLexer, TestSingleComma) {
     Lexer lexer(",");
-    Token tok = lexer.getToken();
-    EXPECT_EQ(tok.type, TokenType::Comma);
-    EXPECT_EQ(tok.line, 1);
-    EXPECT_EQ(tok.literal, "");
+    checkToken(lexer.getToken(), TokenType::Comma, 1, "");
 }
 
 TEST(TestLexer, TestParenCommaParen) {
     Lexer lexer("(,)");
-    Token tok1 = lexer.getToken();
-    Token tok2 = lexer.getToken();
-    Token tok3 = lexer.getToken();
-    EXPECT_EQ(tok1.type, TokenType::LeftParen);
-    EXPECT_EQ(tok1.line, 1);
-    EXPECT_EQ(tok1.literal, "");
-    EXPECT_EQ(tok2.type, TokenType::Comma);
-    EXPECT_EQ(tok2.line, 1);
-    EXPECT_EQ(tok2.literal, "");
-    EXPECT_EQ(tok3.type, TokenType::RightParen);
-    EXPECT_EQ(tok3.line, 1);
-    EXPECT_EQ(tok3.literal, "");
+    checkToken(lexer.getToken(), TokenType::LeftParen, 1, "");
+    checkToken(lexer.getToken(), TokenType::Comma, 1, "");
+    checkToken(lexer.getToken(), TokenType::RightParen, 1, "");
 }
 
 TEST(TestLexer, TestString) {
     Lexer lexer("\"Hi, this is a string.\"");
-    Token tok = lexer.getToken();
-    EXPECT_EQ(tok.type, TokenType::String);
-    EXPECT_EQ(tok.line, 1);
-    EXPECT_EQ(tok.literal, "Hi, this is a string.");
+    checkToken(lexer.getToken(), TokenType::String, 1, "Hi, this is a string.");
 }
 
 TEST(TestLexer, TestIgnoreWhitespace) {
     Lexer lexer("  ( ,) }");
-    Token tok1 = lexer.getToken();
-    Token tok2 = lexer.getToken();
-    Token tok3 = lexer.getToken();
-    Token tok4 = lexer.getToken();
-    EXPECT_EQ(tok1.type, TokenType::LeftParen);
-    EXPECT_EQ(tok1.line, 1);
-    EXPECT_EQ(tok1.literal, "");
-    EXPECT_EQ(tok2.type, TokenType::Comma);
-    EXPECT_EQ(tok2.line, 1);
-    EXPECT_EQ(tok2.literal, "");
-    EXPECT_EQ(tok3.type, TokenType::RightParen);
-    EXPECT_EQ(tok3.line, 1);
-    EXPECT_EQ(tok3.literal, "");
-    EXPECT_EQ(tok4.type, TokenType::RightBrace);
-    EXPECT_EQ(tok4.line, 1);
-    EXPECT_EQ(tok4.literal, "");
+    checkToken(lexer.getToken(), TokenType::LeftParen, 1, "");
+    checkToken(lexer.getToken(), TokenType::Comma, 1, "");
+    checkToken(lexer.getToken(), TokenType::RightParen, 1, "");
+    checkToken(lexer.getToken(), TokenType::RightBrace, 1, "");
 }
 
 TEST(TestLexer, TestFunctionDef) {
     Lexer lexer("def add(a,b) {\r\nreturn a + b\r\n}");
-    Token tok = lexer.getToken();
-    EXPECT_EQ(tok.type, TokenType::Def);
-    EXPECT_EQ(tok.line, 1);
-    EXPECT_EQ(tok.literal, "");
-    tok = lexer.getToken();
-    EXPECT_EQ(tok.type, TokenType::Identifier);
-    EXPECT_EQ(tok.line, 1);
-    EXPECT_EQ(tok.literal, "add");
-    tok = lexer.getToken();
-    EXPECT_EQ(tok.type, TokenType::LeftParen);
-    EXPECT_EQ(tok.line, 1);
-    EXPECT_EQ(tok.literal, "");
-    tok = lexer.getToken();
-    EXPECT_EQ(tok.type, TokenType::Identifier);
-    EXPECT_EQ(tok.line, 1);
-    EXPECT_EQ(tok.literal, "a");
-    tok = lexer.getToken();
-    EXPECT_EQ(tok.type, TokenType::Comma);
-    EXPECT_EQ(tok.line, 1);
-    EXPECT_EQ(tok.literal, "");
-    tok = lexer.getToken();
-    EXPECT_EQ(tok.type, TokenType::Identifier);
-    EXPECT_EQ(tok.line, 1);
-    EXPECT_EQ(tok.literal, "b");
-    tok = lexer.getToken();
-    EXPECT_EQ(tok.type, TokenType::RightParen);
-    EXPECT_EQ(tok.line, 1);
-    EXPECT_EQ(tok.literal, "");
-    tok = lexer.getToken();
-    EXPECT_EQ(tok.type, TokenType::LeftBrace);
-    EXPECT_EQ(tok.line, 1);
-    EXPECT_EQ(tok.literal, "");
-    tok = lexer.getToken();
-    EXPECT_EQ(tok.type, TokenType::EOL);
-    EXPECT_EQ(tok.line, 1);
-    EXPECT_EQ(tok.literal, "");
-    tok = lexer.getToken();
-    EXPECT_EQ(tok.type, TokenType::Return);
-    EXPECT_EQ(tok.line, 2);
-    EXPECT_EQ(tok.literal, "");
-    tok = lexer.getToken();
-    EXPECT_EQ(tok.type, TokenType::Identifier);
-    EXPECT_EQ(tok.line, 2);
-    EXPECT_EQ(tok.literal, "a");
-    tok = lexer.getToken();
-    EXPECT_EQ(tok.type, TokenType::Plus);
-    EXPECT_EQ(tok.line, 2);
-    EXPECT_EQ(tok.literal, "");
-    tok = lexer.getToken();
-    EXPECT_EQ(tok.type, TokenType::Identifier);
-    EXPECT_EQ(tok.line, 2);
-    EXPECT_EQ(tok.literal, "b");
-    tok = lexer.getToken();
-    EXPECT_EQ(tok.type, TokenType::EOL);
-    EXPECT_EQ(tok.line, 2);
-    EXPECT_EQ(tok.literal, "");
-    tok = lexer.getToken();
-    EXPECT_EQ(tok.type, TokenType::RightBrace);
-    EXPECT_EQ(tok.line, 3);
-    EXPECT_EQ(tok.literal, "");
+    checkToken(lexer.getToken(), TokenType::Def, 1, "");
+    checkToken(lexer.getToken(), TokenType::Identifier, 1, "add");
+    checkToken(lexer.getToken(), TokenType::LeftParen, 1, "");
+    checkToken(lexer.getToken(), TokenType::Identifier, 1, "a");
+    checkToken(lexer.getToken(), TokenType::Comma, 1, "");
+    checkToken(lexer.getToken(), TokenType::Identifier, 1, "b");
+    checkToken(lexer.getToken(), TokenType::RightParen, 1, "");
+    checkToken(lexer.getToken(), TokenType::LeftBrace, 1, "");
+    checkToken(lexer.getToken(), TokenType::EOL, 1, "");
+    checkToken(lexer.getToken(), TokenType::Return, 2, "");
+    checkToken(lexer.getToken(), TokenType::Identifier, 2, "a");
+    checkToken(lexer.getToken(), TokenType::Plus, 2, "");
+    checkToken(lexer.getToken(), TokenType::Identifier, 2, "b");
+    checkToken(lexer.getToken(), TokenType::EOL, 2, "");
+    checkToken(lexer.getToken(), TokenType::RightBrace, 3, "");
 }
+
+TEST(TestLexer, TestEatDurianEx) {
+    Lexer lexer("def EatDurianHelper(durian, callback) {\n"
+                "    print durian & \" is eaten!\"\n"
+                "    let success = callback(durian)\n"
+                "    return success\n"
+                "}");
+    checkToken(lexer.getToken(), TokenType::Def, 1, "");
+    checkToken(lexer.getToken(), TokenType::Identifier, 1, "EatDurianHelper");
+    checkToken(lexer.getToken(), TokenType::LeftParen, 1, "");
+    checkToken(lexer.getToken(), TokenType::Identifier, 1, "durian");
+    checkToken(lexer.getToken(), TokenType::Comma, 1, "");
+    checkToken(lexer.getToken(), TokenType::Identifier, 1, "callback");
+    checkToken(lexer.getToken(), TokenType::RightParen, 1, "");
+    checkToken(lexer.getToken(), TokenType::LeftBrace, 1, "");
+    checkToken(lexer.getToken(), TokenType::EOL, 1, "");
+    checkToken(lexer.getToken(), TokenType::Print, 2, "");
+    checkToken(lexer.getToken(), TokenType::Identifier, 2, "durian");
+    checkToken(lexer.getToken(), TokenType::Ampersand, 2, "");
+    checkToken(lexer.getToken(), TokenType::String, 2, " is eaten!");
+    checkToken(lexer.getToken(), TokenType::EOL, 2, "");
+    checkToken(lexer.getToken(), TokenType::Let, 3, "");
+    checkToken(lexer.getToken(), TokenType::Identifier, 3, "success");
+    checkToken(lexer.getToken(), TokenType::Equal, 3, "");
+    checkToken(lexer.getToken(), TokenType::Identifier, 3, "callback");
+    checkToken(lexer.getToken(), TokenType::LeftParen, 3, "");
+    checkToken(lexer.getToken(), TokenType::Identifier, 3, "durian");
+    checkToken(lexer.getToken(), TokenType::RightParen, 3, "");
+    checkToken(lexer.getToken(), TokenType::EOL, 3, "");
+    checkToken(lexer.getToken(), TokenType::Return, 4, "");
+    checkToken(lexer.getToken(), TokenType::Identifier, 4, "success");
+    checkToken(lexer.getToken(), TokenType::EOL, 4, "");
+    checkToken(lexer.getToken(), TokenType::RightBrace, 5, "");
+}
+


### PR DESCRIPTION
---

## :construction_worker: Changes

Added a `checkToken` helper that makes the `TestLexer` tests much cleaner.

Also added a new, more complex unit test.

## :flashlight: Testing Instructions

Unit tests still run correctly.
