### PR TITLE
Fix missing 'virtual' on Visitor interface methods

### DIFF
--- a/src/include/Visitor.h
+++ b/src/include/Visitor.h
@@ -5,24 +5,24 @@
 
 class Visitor {
 private:
-    void visit(AST::AssignStmt *node) = 0;
-    void visit(AST::BinaryExpr *node) = 0;
-    void visit(AST::BlockStmt *node) = 0;
-    void visit(AST::BooleanLit *node) = 0;
-    void visit(AST::BreakStmt *node) = 0;
-    void visit(AST::ErrStmt *node) = 0;
-    void visit(AST::ExprStmt *node) = 0;
-    void visit(AST::FloatLit *node) = 0;
-    void visit(AST::FnCall *node) = 0;
-    void visit(AST::FnDecl *node) = 0;
-    void visit(AST::Identifier *node) = 0;
-    void visit(AST::IfStmt *node) = 0;
-    void visit(AST::LetStmt *node) = 0;
-    void visit(AST::NextStmt *node) = 0;
-    void visit(AST::PrintStmt *node) = 0;
-    void visit(AST::ReturnStmt *node) = 0;
-    void visit(AST::ScanStmt *node) = 0;
-    void  visit(AST::StringLit *node) = 0;
-    void visit(AST::UnaryExpr *node) = 0;
-    void visit(AST::WhileStmt *node) = 0;
+    virtual void visit(AST::AssignStmt *node) = 0;
+    virtual void visit(AST::BinaryExpr *node) = 0;
+    virtual void visit(AST::BlockStmt *node) = 0;
+    virtual void visit(AST::BooleanLit *node) = 0;
+    virtual void visit(AST::BreakStmt *node) = 0;
+    virtual void visit(AST::ErrStmt *node) = 0;
+    virtual void visit(AST::ExprStmt *node) = 0;
+    virtual void visit(AST::FloatLit *node) = 0;
+    virtual void visit(AST::FnCall *node) = 0;
+    virtual void visit(AST::FnDecl *node) = 0;
+    virtual void visit(AST::Identifier *node) = 0;
+    virtual void visit(AST::IfStmt *node) = 0;
+    virtual void visit(AST::LetStmt *node) = 0;
+    virtual void visit(AST::NextStmt *node) = 0;
+    virtual void visit(AST::PrintStmt *node) = 0;
+    virtual void visit(AST::ReturnStmt *node) = 0;
+    virtual void visit(AST::ScanStmt *node) = 0;
+    virtual void visit(AST::StringLit *node) = 0;
+    virtual void visit(AST::UnaryExpr *node) = 0;
+    virtual void visit(AST::WhileStmt *node) = 0;
 };


### PR DESCRIPTION
---

## :construction_worker: Changes

Not sure how this got through Travis but the abstract functions on the `Visitor` interface needed to be declared `virtual` to compile (at least for me locally... perhaps it's a Clang-specific thing?).

## :flashlight: Testing Instructions

It compiles!