### PR TITLE
Some fixes for pretty printer

### DIFF
--- a/src/lexer/Lexer.cpp
+++ b/src/lexer/Lexer.cpp
@@ -10,7 +10,7 @@ Lexer::Lexer(const std::string input)
 
 const Token Lexer::getToken() {
     std::string literal;
-    if (m_iter == m_input.cend()) return Token {TokenType::END, m_line, ""};
+    if (m_iter == m_input.cend() || *m_iter =='\0') return Token {TokenType::END, m_line, ""};
     while (*m_iter == ' ') {
         ++m_iter;
     }

--- a/src/parser/Parser.cpp
+++ b/src/parser/Parser.cpp
@@ -20,6 +20,9 @@ std::unique_ptr<AST::Stmt> Parser::parse() {
 }
 
 std::unique_ptr<AST::Stmt> Parser::parseStmt() {
+    if (m_currToken.type == TokenType::END) {
+        return nullptr;
+    }
     if (m_currToken.type == TokenType::EOL) {
         eatToken(TokenType::EOL);
         return parseStmt();
@@ -93,7 +96,8 @@ std::unique_ptr<AST::Stmt> Parser::parseStmt() {
 
     if (m_currToken.type == TokenType::Def) {
         eatToken(TokenType::Def);
-        Token id = eatToken(TokenType::Identifier);
+        Token id = m_currToken;
+        eatToken(TokenType::Identifier);
         eatToken(TokenType::LeftParen);
         std::vector<std::unique_ptr<AST::Identifier>> params;
         while (m_currToken.type != TokenType::RightParen) {

--- a/src/pretty_printer/PrettyPrinter.cpp
+++ b/src/pretty_printer/PrettyPrinter.cpp
@@ -64,6 +64,9 @@ void PrettyPrinter::visit(AST::FnCall *node) {
     std::cout << " with args ";
     for (auto iter = node->m_args.cbegin(); iter != node->m_args.cend(); ++iter) {
         iter->get()->accept(this);
+        if (iter + 1 != node->m_args.cend()) {
+            std::cout << " ";
+        }
     }
     std::cout << ")";
 };
@@ -74,6 +77,9 @@ void PrettyPrinter::visit(AST::FnDecl *node) {
     std::cout << " with params ";
     for (auto iter = node->m_params.cbegin(); iter != node->m_params.cend(); ++iter) {
         iter->get()->accept(this);
+        if (iter + 1 != node->m_params.cend()) {
+            std::cout << " ";
+        }
     }
     std::cout << " and body ";
     node->m_body->accept(this);
@@ -120,7 +126,9 @@ void PrettyPrinter::visit(AST::PrintStmt *node) {
 };
 
 void PrettyPrinter::visit(AST::ReturnStmt *node) {
-    std::cout << "return;" << std::endl;
+    std::cout << "return ";
+    node->m_expr->accept(this);
+    std::cout << ";" << std::endl;
 };
 
 void PrettyPrinter::visit(AST::ScanStmt *node) {

--- a/src/pretty_printer/main.cpp
+++ b/src/pretty_printer/main.cpp
@@ -15,11 +15,19 @@ int main() {
             fin = true;
         } else {
             input += temp;
+            input += "\n";
         }
     }
     Parser parser {Lexer(input)};
-    auto ast = parser.parse();
     PrettyPrinter pp;
-    ast->accept(&pp);
+    bool done = false;
+    while (!done) {
+        auto ast = parser.parse();
+        if (ast == nullptr) {
+            done = true;
+        } else {
+            ast->accept(&pp);
+        }
+    }
     return 0;
 }


### PR DESCRIPTION
---

## :construction_worker: Changes

I found a couple things in the pretty printer that weren't working that well; in particular, it would break on multi-line input, didn't parse `def` statements correctly, and also always exited with non-zero error codes. The solutions, in order:

* `getline` apparently strips the EOL indicator. So for the pretty printer I just hackily put `\n` back in. Also, it was only parsing one statement of the input, so I put the parser into a `for` loop.
* `def` statements were accidentally storing the `LeftParen` token as the function name, not the actual identifier.
* Apparently checking for `cend` in the lexer iterator doesn't consistently work, so I added a check for `\0` (the null terminator). Also, the parser wasn't handling `END` tokens correctly. It *should* be returning a `nullptr` (from the call to `parseExpr()`) but apparently this wasn't happening, so again I just added a check for it at the top of the parser.

There's a few other small niceties as well.

## :flashlight: Testing Instructions

Tried multi-line input, e.g.
```
a + b
b * a
fin
```
and it correctly output
```
(+ (ident a) (ident b));
(* (ident b) (ident a));
```

`def` statements do seem to work if I run them though the debugger, though I think there's still some sort of lexer issue going on, as they work very inconsistently otherwise.