### PR TITLE
Coverage script

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -20,9 +20,9 @@ script:
   - mkdir build ; cd build ; cmake -DCMAKE_BUILD_TYPE=Debug ..
   - make
   - ./durian_test
-after_success: |
-  cd ${TRAVIS_BUILD_DIR} &&
-  lcov --directory . --capture --output-file coverage.info &&
-  lcov --remove coverage.info '/Library/*' '/usr/*' '*/test/*' '*/googletest/*' --output-file coverage.info &&
-  lcov --list coverage.info &&
-  bash <(curl -s https://codecov.io/bash) -X gcov || echo "Codecov did not collect coverage reports"
+after_success:
+  - cd ${TRAVIS_BUILD_DIR}
+  - lcov --directory . --capture --output-file coverage.info
+  - lcov --remove coverage.info '/Library/*' '/usr/*' '*/test/*' '*/googletest/*' --output-file coverage.info
+  - lcov --list coverage.info
+  - bash <(curl -s https://codecov.io/bash) -X gcov || echo "Codecov did not collect coverage reports"

--- a/.travis.yml
+++ b/.travis.yml
@@ -7,16 +7,12 @@ notifications:
 addons:
   apt:
     sources:
-      - llvm-toolchain-trusty-5.0
       - ubuntu-toolchain-r-test
     packages:
-      - clang-5.0
       - g++-7
       - lcov
 compiler:
-  - gcc # todo: choose compiler
-env:
-  - MATRIX_EVAL="CC=clang-5.0 && CXX=clang++-5.0"
+  - gcc
 
 install:
   - git submodule update --init --recursive

--- a/.travis.yml
+++ b/.travis.yml
@@ -20,9 +20,9 @@ script:
   - mkdir build ; cd build ; cmake -DCMAKE_BUILD_TYPE=Debug ..
   - make
   - ./durian_test
-after_success:
-  - cd ${TRAVIS_BUILD_DIR}
-  - lcov --directory . --capture --output-file coverage.info # capture coverage info
-  - lcov --remove coverage.info '/usr/*' --output-file coverage.info # filter out system
-  - lcov --list coverage.info #debug info
-  - bash <(curl -s https://codecov.io/bash) || echo "Codecov did not collect coverage reports"
+after_success: |
+  cd ${TRAVIS_BUILD_DIR} &&
+  lcov --directory . --capture --output-file coverage.info &&
+  lcov --remove coverage.info '/Library/*' '/usr/*' '*/test/*' '*/googletest/*' --output-file coverage.info &&
+  lcov --list coverage.info &&
+  bash <(curl -s https://codecov.io/bash) -X gcov || echo "Codecov did not collect coverage reports"

--- a/README.md
+++ b/README.md
@@ -1,4 +1,7 @@
+
 # 🍍 durian
+
+[![codecov](https://codecov.io/gh/ubclaunchpad/durian/branch/master/graph/badge.svg)](https://codecov.io/gh/ubclaunchpad/durian)
 
 ## Anatomy of a Durian
 

--- a/README.md
+++ b/README.md
@@ -1,6 +1,7 @@
 
 # 🍍 durian
 
+[![Build Status](https://travis-ci.org/ubclaunchpad/durian.svg?branch=master)](https://travis-ci.org/ubclaunchpad/durian)
 [![codecov](https://codecov.io/gh/ubclaunchpad/durian/branch/master/graph/badge.svg)](https://codecov.io/gh/ubclaunchpad/durian)
 
 ## Anatomy of a Durian

--- a/coverage.sh
+++ b/coverage.sh
@@ -1,0 +1,8 @@
+#!/bin/sh
+set -euxo pipefail
+
+# note: must have gcov and lcov installed
+
+lcov --directory . --capture --output-file coverage.info
+lcov --remove coverage.info '/Library/*' '/usr/*' '*/test/*' '*/googletest/*' --output-file coverage.info
+lcov --list coverage.info


### PR DESCRIPTION
---

## :construction_worker: Changes

Adds a script so we can obtain coverage reports locally on Unix systems, removes unnecessary Travis configurations, updates coverage so that our reports only include our source files (and not tests or library files), and adds a Codecov.io badge to the repo!

## :flashlight: Testing Instructions

See [here](https://codecov.io/gh/ubclaunchpad/durian/commit/f37e8deb05b751f81ffb24ebdb1a2779c89b9db5) for report from this commit's push build on Travis (only 40% coverage, boo!).