### PR TITLE
Add more parser unit tests

### DIFF
--- a/src/parser/Parser.cpp
+++ b/src/parser/Parser.cpp
@@ -68,7 +68,8 @@ std::unique_ptr<AST::Stmt> Parser::parseStmt() {
 
     if (m_currToken.type == TokenType::Let) {
         eatToken(TokenType::Let);
-        Token id = eatToken(TokenType::Identifier);
+        Token id = m_currToken;
+        eatToken(TokenType::Identifier);
         eatToken(TokenType::Equal);
         auto val = parseExpr();
         return std::make_unique<AST::LetStmt>(std::make_unique<AST::Identifier>(id.literal), std::move(val));
@@ -88,7 +89,8 @@ std::unique_ptr<AST::Stmt> Parser::parseStmt() {
 
     if (m_currToken.type == TokenType::Scan) {
         eatToken(TokenType::Scan);
-        Token id = eatToken(TokenType::Identifier);
+        Token id = m_currToken;
+        eatToken(TokenType::Identifier);
         return std::make_unique<AST::ScanStmt>(std::make_unique<AST::Identifier>(id.literal));
     }
 


### PR DESCRIPTION
## :construction_worker: Changes

Add quite a few more unit tests for the parser (we're up to 80% coverage but still not quite to the 90+% range, sadly).

Unfortunately I still haven't gotten function declarations working. The strange thing is that they seem to work 100% of the time in the debugger, but _not_ otherwise. It seems like the issue is in the lexer--in particular after `def f(a,b)` it runs into invalid (EOF?) characters... even though it left the iterator on a valid character. Nothing should be touching the iterator in between calls to `getToken()`, and at least according to cppreference the const iterator on a string can't suffer invalidation. So... 🤷‍♀️ I have no idea, guys.

## :flashlight: Testing Instructions

The unit tests run (yay!).