### PR TITLE
String literal compilation

### DIFF
--- a/src/compiler/Compiler.cpp
+++ b/src/compiler/Compiler.cpp
@@ -76,11 +76,15 @@ void Compiler::visit(AST::StringLit *node) {
     if (m_staticStringMap.find(lit) == m_staticStringMap.end()) {
         // string not present in static data, add
         idx = m_currStaticStringIndex;
+        std::array<uint8_t, sizeof(uint64_t)> tmpStr = {};
+        std::memcpy(tmpStr.data(), lit.data(), lit.size());
+        for (auto val : tmpStr) {
+            m_staticStrings.push_back(val);
+        }
         m_staticStringMap.insert({lit, m_currStaticStringIndex});
         m_currStaticStringIndex += lit.size();
     } else {
         idx = m_staticStringMap.at(lit);
-        std::array<uint8_t, sizeof(uint64_t)> tmp = {};
     }
     std::memcpy(tmp.data(), &idx, sizeof(uint64_t));
     for (auto val : tmp) {

--- a/src/compiler/Compiler.cpp
+++ b/src/compiler/Compiler.cpp
@@ -69,14 +69,15 @@ void Compiler::visit(AST::ReturnStmt *node) {}
 void Compiler::visit(AST::ScanStmt *node) {}
 
 void Compiler::visit(AST::StringLit *node) {
-    const std::string lit = node->m_value;
+    m_buffer.push_back(Opcode::NEWSTR8);
 
-    std::array<uint8_t, sizeof(uint64_t)> tmp = {};
-    uint64_t idx;
+    const std::string lit = node->m_value;
+    std::array<uint8_t, sizeof(uint32_t)> tmp = {};
+    uint32_t idx;
     if (m_staticStringMap.find(lit) == m_staticStringMap.end()) {
         // string not present in static data, add
         idx = m_currStaticStringIndex;
-        std::array<uint8_t, sizeof(uint64_t)> tmpStr = {};
+        std::array<uint8_t, sizeof(uint32_t)> tmpStr = {};
         std::memcpy(tmpStr.data(), lit.data(), lit.size());
         for (auto val : tmpStr) {
             m_staticStrings.push_back(val);
@@ -86,11 +87,10 @@ void Compiler::visit(AST::StringLit *node) {
     } else {
         idx = m_staticStringMap.at(lit);
     }
-    std::memcpy(tmp.data(), &idx, sizeof(uint64_t));
+    std::memcpy(tmp.data(), &idx, sizeof(uint32_t));
     for (auto val : tmp) {
         m_buffer.push_back(val);
     }
-    m_buffer.push_back(Opcode::NEWSTR8);
 }
 
 void Compiler::visit(AST::UnaryExpr *node) {

--- a/src/include/Compiler.h
+++ b/src/include/Compiler.h
@@ -10,8 +10,8 @@ class Compiler : public Visitor {
     std::vector<unsigned char> m_buffer;
     std::vector<unsigned char> m_header;
     std::vector<uint8_t> m_staticStrings;
-    std::unordered_map<std::string, uint64_t> m_staticStringMap;
-    uint64_t m_currStaticStringIndex;
+    std::unordered_map<std::string, uint32_t> m_staticStringMap;
+    uint32_t m_currStaticStringIndex;
 public:
     std::vector<unsigned char> getBuffer() { return m_buffer; }
     std::vector<uint8_t> getStaticStrings() { return m_staticStrings; };

--- a/src/include/Compiler.h
+++ b/src/include/Compiler.h
@@ -9,10 +9,12 @@
 class Compiler : public Visitor {
     std::vector<unsigned char> m_buffer;
     std::vector<unsigned char> m_header;
+    std::vector<uint8_t> m_staticStrings;
     std::unordered_map<std::string, uint64_t> m_staticStringMap;
     uint64_t m_currStaticStringIndex;
 public:
     std::vector<unsigned char> getBuffer() { return m_buffer; }
+    std::vector<uint8_t> getStaticStrings() { return m_staticStrings; };
     virtual void visit(AST::AssignStmt *node) override;
     virtual void visit(AST::BinaryExpr *node) override;
     virtual void visit(AST::BlockStmt *node) override;

--- a/src/include/Compiler.h
+++ b/src/include/Compiler.h
@@ -1,5 +1,7 @@
 #pragma once
 
+#include <unordered_map>
+
 #include <Parser.h>
 #include <ASTree.h>
 #include <Visitor.h>
@@ -7,6 +9,8 @@
 class Compiler : public Visitor {
     std::vector<unsigned char> m_buffer;
     std::vector<unsigned char> m_header;
+    std::unordered_map<std::string, uint64_t> m_staticStringMap;
+    uint64_t m_currStaticStringIndex;
 public:
     std::vector<unsigned char> getBuffer() { return m_buffer; }
     virtual void visit(AST::AssignStmt *node) override;


### PR DESCRIPTION
:tickets: **Ticket(s)**: Closes #59

---

## :construction_worker: Changes

Implements bytecode generation for string literals and cleans up main in preparation for bytecode file loading.

## :flashlight: Testing Instructions

At the moment it won't correctly execute anything because the metadata for the bytecode file is not yet being generated. However you can still use the `-c` flag to simple compile to bytecode and see that the strings are behaving as expected.