### PR TITLE
Standardize integer types

### DIFF
--- a/src/compiler/Compiler.cpp
+++ b/src/compiler/Compiler.cpp
@@ -30,10 +30,10 @@ void Compiler::visit(AST::ExprStmt *node) {
 }
 
 void Compiler::visit(AST::FloatLit *node) {
-    std::array<unsigned char, sizeof(double)> tmp = {};
+    std::array<Bytecode, sizeof(double)> tmp = {};
     memcpy(tmp.data(), &node->m_value, sizeof(double));
     m_buffer.push_back(Opcode::DCONST);
-    for (unsigned char val : tmp) {
+    for (auto val : tmp) {
         m_buffer.push_back(val);
     }
 }
@@ -47,10 +47,10 @@ void Compiler::visit(AST::Identifier *node) {}
 void Compiler::visit(AST::IfStmt *node) {}
 
 void Compiler::visit(AST::IntegerLit *node) {
-    std::array<unsigned char, sizeof(double)> tmp = {};
+    std::array<Bytecode, sizeof(double)> tmp = {};
     memcpy(tmp.data(), &node->m_value, sizeof(int64_t));
     m_buffer.push_back(Opcode::ICONST);
-    for (unsigned char val : tmp) {
+    for (auto val : tmp) {
         m_buffer.push_back(val);
     }
 }
@@ -72,12 +72,12 @@ void Compiler::visit(AST::StringLit *node) {
     m_buffer.push_back(Opcode::NEWSTR8);
 
     const std::string lit = node->m_value;
-    std::array<uint8_t, sizeof(uint32_t)> tmp = {};
-    uint32_t idx;
+    std::array<Bytecode, sizeof(uint32_t)> tmp = {};
+    BytecodePointer idx;
     if (m_staticStringMap.find(lit) == m_staticStringMap.end()) {
         // string not present in static data, add
         idx = m_currStaticStringIndex;
-        std::array<uint8_t, sizeof(uint32_t)> tmpStr = {};
+        std::array<Bytecode, sizeof(uint32_t)> tmpStr = {};
         std::memcpy(tmpStr.data(), lit.data(), lit.size());
         for (auto val : tmpStr) {
             m_staticStrings.push_back(val);

--- a/src/include/Compiler.h
+++ b/src/include/Compiler.h
@@ -2,19 +2,20 @@
 
 #include <unordered_map>
 
-#include <Parser.h>
 #include <ASTree.h>
+#include <Parser.h>
+#include <Types.h>
 #include <Visitor.h>
 
 class Compiler : public Visitor {
-    std::vector<unsigned char> m_buffer;
-    std::vector<unsigned char> m_header;
-    std::vector<uint8_t> m_staticStrings;
-    std::unordered_map<std::string, uint32_t> m_staticStringMap;
-    uint32_t m_currStaticStringIndex;
+    std::vector<Bytecode> m_buffer;
+    std::vector<Bytecode> m_header;
+    std::vector<Bytecode> m_staticStrings;
+    std::unordered_map<std::string, BytecodePointer> m_staticStringMap;
+    BytecodePointer m_currStaticStringIndex;
 public:
-    std::vector<unsigned char> getBuffer() { return m_buffer; }
-    std::vector<uint8_t> getStaticStrings() { return m_staticStrings; };
+    std::vector<Bytecode> getBuffer() { return m_buffer; }
+    std::vector<Bytecode> getStaticStrings() { return m_staticStrings; };
     virtual void visit(AST::AssignStmt *node) override;
     virtual void visit(AST::BinaryExpr *node) override;
     virtual void visit(AST::BlockStmt *node) override;

--- a/src/include/Types.h
+++ b/src/include/Types.h
@@ -1,0 +1,6 @@
+#pragma once
+
+#include <cstdint>
+
+typedef uint8_t Bytecode;
+typedef int64_t BytecodePointer;

--- a/src/include/VM.h
+++ b/src/include/VM.h
@@ -1,24 +1,25 @@
 #pragma once
 
 #include <DurianObject.h>
+#include <Types.h>
 
 #include <array>
 
 class VM {
-    unsigned char *m_code;     // Pointer to bytecode
-    int64_t m_pc;                  // Program Counter
-    int64_t m_sp;                  // Stack Pointer
-    int64_t m_fp;                  // Frame Pointer
+    Bytecode* m_code;     // Pointer to bytecode
+    BytecodePointer m_pc;                  // Program Counter
+    BytecodePointer m_sp;                  // Stack Pointer
+    BytecodePointer m_fp;                  // Frame Pointer
     static const int STACK_SIZE = 256;
     std::array<DurianObject, STACK_SIZE> m_stack; // Stack
 public:
-    VM(unsigned char *);
+    VM(Bytecode*);
     ~VM() = default;
     int run();
 private:
     void push(DurianObject);
     DurianObject pop();
-    unsigned char nextBytecode();
+    Bytecode nextBytecode();
     void typeError(const char *operand, DurianObject a);
     void typeError(const char *operand, DurianObject a, DurianObject b);
 };

--- a/src/interpreter/vm/VM.cpp
+++ b/src/interpreter/vm/VM.cpp
@@ -10,7 +10,7 @@
 
 // Public
 
-VM::VM(unsigned char *bytecode) :
+VM::VM(Bytecode *bytecode) :
     m_code(bytecode),
     m_pc(0),
     m_sp(0),
@@ -20,12 +20,12 @@ VM::VM(unsigned char *bytecode) :
 
 int VM::run() {
     while(true) {
-        unsigned char opcode = nextBytecode();
+        Bytecode opcode = nextBytecode();
         DURIAN_DEBUG_LOG("%x\n", opcode);
         DurianObject a, b;
         int32_t jumpLen; // Jump length
-        unsigned char *p_headerStr; // String (length: 8 bytes, value: length bytes) pointer
-        unsigned char *p_fnAddress; // Function Address
+        Bytecode *p_headerStr; // String (length: 8 bytes, value: length bytes) pointer
+        Bytecode *p_fnAddress; // Function Address
         switch (opcode) {
             case Opcode::HALT: return 0;
             case Opcode::NOP: break;


### PR DESCRIPTION
## :construction_worker: Changes

Standardizes the integer types: bytecode is unsigned 8-bit integers, pointers into bytecode is unsigned 64-bit integers.

## :flashlight: Testing Instructions

Everything still builds and runs.